### PR TITLE
Add is_component_build flag to v8gen.py command

### DIFF
--- a/7.0-fpm/Dockerfile
+++ b/7.0-fpm/Dockerfile
@@ -15,8 +15,7 @@ RUN cd /tmp && fetch v8
 RUN cd /tmp/v8 && gclient sync
 
 # Setup GN
-RUN cd /tmp/v8 && tools/dev/v8gen.py -vv x64.release
-RUN cd /tmp/v8 && echo is_component_build = true >> out.gn/x64.release/args.gn
+RUN cd /tmp/v8 && tools/dev/v8gen.py -vv x64.release -- is_component_build=true
 
 # Build
 RUN cd /tmp/v8 && ninja -C out.gn/x64.release/


### PR DESCRIPTION
Previously, it was appended using `echo >>`. However, that wasn't picked up by `ninja` since it would've required an intermediary `gn gen out.gn/x64.release` step. By passing the additional build flag directly to `v8gen.py`, we ensure that `ninja` picks it up.

Fixes https://github.com/10up/twentysixteenreact/issues/9